### PR TITLE
Update eID_klient.app to version 4.3

### DIFF
--- a/Casks/eid-sk.rb
+++ b/Casks/eid-sk.rb
@@ -1,6 +1,6 @@
 cask 'eid-sk' do
-    version '4.1'
-    sha256 '3206e00c6de5c0cc10b35ecc10d565861ee08ece8347460e593cb9882dbd22bd'
+    version '4.3'
+    sha256 '776341f1d929218636574ff9bc7f133552981e85c0a20772f1a486e40e96c461'
 
     # eidas.minv.sk/TCTokenService/download was verified as official when first introduced to the cask
     url 'https://eidas.minv.sk/downloadservice/eidklient/mac/eID_klient.dmg'


### PR DESCRIPTION
Updated the version and expected SHA hash for version 4.3 (latest as of writing this PR) 